### PR TITLE
Fix absolute path checks on Windows.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oo-cli",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A typescript-first object-oriented command line interface framework",
   "repository": "https://github.com/levilansing/oo-cli",
   "license": "MIT",

--- a/src/build.ts
+++ b/src/build.ts
@@ -7,7 +7,7 @@ const inProduction = process.env.NODE_ENV === 'production' || ['-p', '--producti
 
 const rootPath = process.cwd();
 let {basePath} = ooCliConfig;
-if (!/^[\\/]/.test(basePath)) {
+if (!path.isAbsolute(basePath)) {
   basePath = path.join(rootPath, basePath);
 }
 configure({basePath});
@@ -21,7 +21,7 @@ if (configPath) {
   // tslint:disable-next-line:no-var-requires
   const config = require(configPath);
   if (config.basePath) {
-    if (!/^\//.test(config.basePath)) {
+    if (!path.isAbsolute(config.basePath)) {
       config.basePath = path.join(rootPath, config.basePath);
     }
   }

--- a/src/build/buildManifest.ts
+++ b/src/build/buildManifest.ts
@@ -10,10 +10,10 @@ export function buildManifest(config: OoCliConfig, basePath: string): ManifestDe
 
   config.search.forEach((pattern) => {
     let searchPath = pattern;
-    if (!/^[\\/]/.test(searchPath)) {
+    if (!path.isAbsolute(searchPath)) {
       searchPath = path.join(config.basePath, searchPath);
     }
-    if (!/^[\\/]/.test(searchPath)) {
+    if (!path.isAbsolute(searchPath)) {
       searchPath = path.join(process.cwd(), searchPath);
     }
     glob.sync(searchPath)


### PR DESCRIPTION
Absolute paths begin with the partition name on Windows.
This fixes search path construction in `buildManifest`.